### PR TITLE
Simple partitioning of Neo4j imported data

### DIFF
--- a/okapi-neo4j-io/src/main/scala/org/opencypher/okapi/neo4j/io/EntityReader.scala
+++ b/okapi-neo4j-io/src/main/scala/org/opencypher/okapi/neo4j/io/EntityReader.scala
@@ -42,6 +42,16 @@ object EntityReader {
         |RETURN id($entityVarName) AS $idPropertyKey$props""".stripMargin
   }
 
+  def countingQuery(labels: Set[String], maybeMetaLabel: Option[String] = None): String = {
+    val allLabels = labels ++ maybeMetaLabel
+    val labelCount = allLabels.size
+
+    s"""|MATCH ($entityVarName:${allLabels.mkString(":")})
+        |WHERE length(labels($entityVarName)) = $labelCount
+        |RETURN count(*) AS c""".stripMargin
+
+  }
+
   def flatRelTypeQuery(relType: String, schema: Schema, maybeMetaLabel: Option[String] = None): String ={
     val props = schema.relationshipPropertyKeys(relType).propertyExtractorString
     val metaLabel = maybeMetaLabel.map(m => s":$m").getOrElse("")

--- a/spark-cypher/src/main/scala/org/opencypher/spark/impl/io/neo4j/external/Neo4jRDD.scala
+++ b/spark-cypher/src/main/scala/org/opencypher/spark/impl/io/neo4j/external/Neo4jRDD.scala
@@ -43,7 +43,9 @@ private class Neo4jRDD(
 
     val neo4jPartition: Neo4jPartition = partition.asInstanceOf[Neo4jPartition]
 
-    Executor.execute(neo4jConfig, query, parameters ++ neo4jPartition.window).sparkRows
+    val pageQuery = s"$query SKIP $$_skip LIMIT $$_limit"
+
+    Executor.execute(neo4jConfig, pageQuery, parameters ++ neo4jPartition.window).sparkRows
   }
 
   override protected def getPartitions: Array[Partition] = {


### PR DESCRIPTION
This scheme uses a hard-coded partitioning into 10 partitions instead of
1. The idea uses `SKIP` and `LIMIT` in the tables-for-labels queries
that are sent to the Neo4j server. We count the total number before we
initialise the import queries to make batches evenly sized.

Co-authored-by: Tobias Johansson <tobias.johansson@neotechnology.com>