### PR TITLE
Expression Type Checking

### DIFF
--- a/morpheus-tck/src/generator/scala/org/opencypher/morpheus/testing/MorpheusTestGenerator.scala
+++ b/morpheus-tck/src/generator/scala/org/opencypher/morpheus/testing/MorpheusTestGenerator.scala
@@ -32,8 +32,8 @@ import org.opencypher.okapi.impl.exception.IllegalArgumentException
 import org.opencypher.okapi.tck.test.AcceptanceTestGenerator
 
 object MorpheusTestGenerator extends App {
-  val imports = List("import MorpheusTestSuite",
-    "import ScanGraphFactory")
+  val imports = List("import org.opencypher.morpheus.testing.MorpheusTestSuite",
+    "import org.opencypher.morpheus.testing.support.creation.graphs.ScanGraphFactory")
   val generator = AcceptanceTestGenerator(imports,
     graphFactoryName = "ScanGraphFactory",
     createGraphMethodName = "initGraph",

--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/PredicateTests.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/PredicateTests.scala
@@ -179,13 +179,18 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
     it("compares less than between different types") {
 
       // Given
-      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+      val given = initGraph(
+        """CREATE (:A {val: 4})-[:REL]->(:B {val2: 1.0}),
+          |       (:A {val: 1})-[:REL]->(:B {val2: 4.0})
+        """.stripMargin)
 
       // When
       val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val < b.val2 RETURN a.val")
 
       // Then
-      result.records.collect.toBag shouldBe empty
+      result.records.collect.toBag should equal(Bag(
+        CypherMap("a.val" -> 1)
+      ))
     }
 
     it("less than or equal") {
@@ -209,13 +214,19 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
     it("compares less than or equal between different types") {
 
       // Given
-      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+      val given = initGraph(
+        """CREATE (:A {val: 4})-[:REL]->(:B {val2: 4.0}),
+          |       (:A {val: 1})-[:REL]->(:B {val2: 4.0})
+        """.stripMargin)
 
       // When
       val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val <= b.val2 RETURN a.val")
 
       // Then
-      result.records.collect.toBag shouldBe empty
+      result.records.collect.toBag should equal(Bag(
+        CypherMap("a.val" -> 4),
+        CypherMap("a.val" -> 1)
+      ))
     }
 
     it("greater than") {
@@ -234,13 +245,18 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
     it("compares greater than between different types") {
 
       // Given
-      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+      val given = initGraph(
+        """CREATE (:A {val: 4})-[:REL]->(:B {val2: 1.0}),
+          |       (:A {val: 1})-[:REL]->(:B {val2: 4.0})
+        """.stripMargin)
 
       // When
       val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val > b.val2 RETURN a.val")
 
       // Then
-      result.records.collect.toBag shouldBe empty
+      result.records.collect.toBag should equal(Bag(
+        CypherMap("a.val" -> 4)
+      ))
     }
 
     it("greater than or equal") {
@@ -260,13 +276,19 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
     it("compares greater than or equal between different types") {
 
       // Given
-      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+      val given = initGraph(
+        """CREATE (:A {val: 4})-[:REL]->(:B {val2: 1.0}),
+          |       (:A {val: 4})-[:REL]->(:B {val2: 4.0})
+        """.stripMargin)
 
       // When
       val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val >= b.val2 RETURN a.val")
 
       // Then
-      result.records.collect.toBag shouldBe empty
+      result.records.collect.toBag should equal(Bag(
+        CypherMap("a.val" -> 4),
+        CypherMap("a.val" -> 4)
+      ))
     }
   }
 

--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/PredicateTests.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/PredicateTests.scala
@@ -199,8 +199,11 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
       // Given
       val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
 
+      // Where
+      val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val < b.val2 RETURN a.val")
+
       // Then
-      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val < b.val2 RETURN a.val"))
+      result.records.collect.toBag shouldBe empty
     }
 
     it("less than or equal") {
@@ -244,8 +247,11 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
       // Given
       val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
 
+      // Where
+      val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val <= b.val2 RETURN a.val")
+
       // Then
-      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val <= b.val2 RETURN a.val"))
+      result.records.collect.toBag shouldBe empty
     }
 
     it("greater than") {
@@ -283,8 +289,11 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
       // Given
       val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
 
+      // Where
+      val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val > b.val2 RETURN a.val")
+
       // Then
-      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val > b.val2 RETURN a.val"))
+      result.records.collect.toBag shouldBe empty
     }
 
     it("greater than or equal") {
@@ -324,8 +333,11 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
       // Given
       val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
 
+      // Where
+      val result = given.cypher("MATCH (a:A)-->(b:B) WHERE a.val >= b.val2 RETURN a.val")
+
       // Then
-      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val >= b.val2 RETURN a.val"))
+      result.records.collect.toBag shouldBe empty
     }
   }
 

--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/PredicateTests.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/PredicateTests.scala
@@ -28,6 +28,7 @@ package org.opencypher.morpheus.impl.acceptance
 
 import org.opencypher.morpheus.testing.MorpheusTestSuite
 import org.opencypher.okapi.api.value.CypherValue._
+import org.opencypher.okapi.impl.exception.NoSuitableSignatureForExpr
 import org.opencypher.okapi.testing.Bag
 import org.opencypher.okapi.testing.Bag._
 
@@ -193,6 +194,15 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
       ))
     }
 
+    it("fails when comparing less than between incompatible types") {
+
+      // Given
+      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+
+      // Then
+      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val < b.val2 RETURN a.val"))
+    }
+
     it("less than or equal") {
       // Given
       val given = initGraph(
@@ -229,6 +239,15 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
       ))
     }
 
+    it("fails when comparing less than or equal between incompatible types") {
+
+      // Given
+      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+
+      // Then
+      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val <= b.val2 RETURN a.val"))
+    }
+
     it("greater than") {
       // Given
       val given = initGraph("""CREATE (:Node {val: 4})-[:REL]->(:Node {val: 5})""")
@@ -257,6 +276,15 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
       result.records.collect.toBag should equal(Bag(
         CypherMap("a.val" -> 4)
       ))
+    }
+
+    it("fails when comparing greater than between incompatible types") {
+
+      // Given
+      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+
+      // Then
+      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val > b.val2 RETURN a.val"))
     }
 
     it("greater than or equal") {
@@ -289,6 +317,15 @@ class PredicateTests extends MorpheusTestSuite with ScanGraphInit {
         CypherMap("a.val" -> 4),
         CypherMap("a.val" -> 4)
       ))
+    }
+
+    it("fails when comparing greater than or equal between different types") {
+
+      // Given
+      val given = initGraph("""CREATE (:A {val: 4})-[:REL]->(:B {val2: 'string'})""")
+
+      // Then
+      a[NoSuitableSignatureForExpr] shouldBe thrownBy(given.cypher("MATCH (a:A)-->(b:B) WHERE a.val >= b.val2 RETURN a.val"))
     }
   }
 

--- a/okapi-api/src/main/scala/org/opencypher/okapi/impl/exception/InternalException.scala
+++ b/okapi-api/src/main/scala/org/opencypher/okapi/impl/exception/InternalException.scala
@@ -54,6 +54,8 @@ final case class IllegalArgumentException(expected: Any, actual: Any = "none", e
 
 final case class UnsupportedOperationException(msg: String, cause: Option[Throwable] = None) extends InternalException(msg, cause)
 
+final case class NoSuitableSignatureForExpr(msg: String, cause: Option[Throwable] = None) extends InternalException(msg, cause)
+
 final case class GraphNotFoundException(msg: String, cause: Option[Throwable] = None) extends InternalException(msg, cause)
 
 final case class InvalidGraphException(msg: String, cause: Option[Throwable] = None) extends InternalException(msg, cause)

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -631,15 +631,8 @@ sealed trait FunctionExpr extends Expr {
          case None => typ
         }
       case None =>
-        typePropagationFunction match{
-          case Some(_: ChildNullPropagation) if children.exists(_.cypherType == CTNull)   => CTNull
-          case _ => throw UnsupportedOperationException(s"Type signature ${getClass.getSimpleName}($joinedCypherType) is not supported.")
-        }
-    }
-
-    }
-      case None =>  throw UnsupportedOperationException(s"Type signature ${getClass.getSimpleName}($joinedCypherType) is not supported.")
-        case None => throw UnsupportedOperationException(s"Type signature ${getClass.getSimpleName}($joinedCypherType) is not supported.")
+          if (children.exists(_.cypherType == CTNull)) CTNull //todo: check corner cases
+          else throw UnsupportedOperationException(s"Type signature ${getClass.getSimpleName}($joinedCypherType) is not supported.")
     }
   }
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -646,7 +646,7 @@ sealed trait UnaryFunctionExpr extends FunctionExpr {
 }
 
 final case class Id(expr: Expr) extends UnaryFunctionExpr {
-  override val cypherType: CypherType = childNullPropagatesTo(CTIdentity)
+  override val cypherType: CypherType = cypherType(Some(ChildNullPropagation()))
 
   def signature(cypherType: CypherType): Option[CypherType] = cypherType match {
     case CTNode | CTRelationship => Some(CTIdentity)
@@ -893,10 +893,9 @@ final case class BitwiseOr(lhs: Expr, rhs: Expr) extends BinaryExpr {
 }
 
 // Mathematical functions
-trait UnaryMathematicalFunctionExpr extends UnaryFunctionExpr {
+//todo: abstract class instead of trait (get outPutCypherType as parameter)
+sealed abstract class UnaryMathematicalFunctionExpr(outPutCypherType : CypherType) extends UnaryFunctionExpr {
   def cypherType: CypherType = cypherType(Some(NullabilityPropagation()))
-
-  def outPutCypherType: CypherType
 
   def signature(cypherType: CypherType): Option[CypherType] = cypherType match {
     case CTNumber => Some(outPutCypherType)
@@ -904,21 +903,13 @@ trait UnaryMathematicalFunctionExpr extends UnaryFunctionExpr {
   }
 }
 
-final case class Sqrt(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Sqrt(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Log(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Log(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Log10(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Log10(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Exp(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Exp(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
 case object E extends NullaryFunctionExpr {
   override val cypherType: CypherType = CTFloat
@@ -930,76 +921,46 @@ case object Pi extends NullaryFunctionExpr {
 
 // Numeric functions
 
-final case class Abs(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTNumber
-}
+final case class Abs(expr: Expr) extends UnaryMathematicalFunctionExpr(CTNumber)
 
-final case class Ceil(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTInteger
-}
+final case class Ceil(expr: Expr) extends UnaryMathematicalFunctionExpr(CTInteger)
 
-final case class Floor(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTInteger
-}
+final case class Floor(expr: Expr) extends UnaryMathematicalFunctionExpr(CTInteger)
 
 case object Rand extends NullaryFunctionExpr {
   override val cypherType: CypherType = CTFloat
 }
 
-final case class Round(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTInteger
-}
+final case class Round(expr: Expr) extends UnaryMathematicalFunctionExpr(CTInteger)
 
-final case class Sign(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTInteger
-}
+final case class Sign(expr: Expr) extends UnaryMathematicalFunctionExpr(CTInteger)
 
 // Trigonometric functions
 
-final case class Acos(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Acos(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Asin(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Asin(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Atan(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Atan(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
 final case class Atan2(expr1: Expr, expr2: Expr) extends FunctionExpr {
   override val cypherType: CypherType = childNullPropagatesTo(CTFloat)
   override def exprs: List[Expr] = List(expr1, expr2)
 }
 
-final case class Cos(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Cos(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Cot(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Cot(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Degrees(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Degrees(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Haversin(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Haversin(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Radians(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Radians(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Sin(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Sin(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
-final case class Tan(expr: Expr) extends UnaryMathematicalFunctionExpr {
-  override def outPutCypherType: CypherType = CTFloat
-}
+final case class Tan(expr: Expr) extends UnaryMathematicalFunctionExpr(CTFloat)
 
 // Time functions
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -131,7 +131,7 @@ sealed trait TypeValidatedExpr extends Expr{
           case None => typ
         }
       case None =>
-        if (children.exists(_.cypherType == CTNull)) CTNull //todo: check corner cases (cases where no Propagation is specified)
+        if (children.exists(_.cypherType == CTNull)) CTNull
         else throw NoSuitableSignatureForExpr(s"Type signature ${getClass.getSimpleName}($materialTypes) is not supported.")
     }
   }
@@ -388,7 +388,7 @@ sealed trait InequalityExprSignature {
   def signature(lhsType: CypherType, rhsType: CypherType): Option[CypherType] = lhsType -> rhsType match {
     case (n1, n2) if n1.subTypeOf(CTNumber) && n2.subTypeOf(CTNumber) => Some(CTBoolean)
     case (c1, c2) if c1.couldBeSameTypeAs(c2) => Some(CTBoolean)
-    case _ => None
+    case _ => Some(CTVoid)
   }
 }
 
@@ -827,7 +827,7 @@ final case class ToUpper(expr: Expr) extends UnaryStringFunctionExpr
 final case class ToLower(expr: Expr) extends UnaryStringFunctionExpr
 
 final case class Properties(expr: Expr)(override val cypherType: CypherType) extends UnaryFunctionExpr {
-  //todo: actually not needed here as type already checked at ExpressionConverter
+  //actually not used here as type already checked at ExpressionConverter
   override def signature(inputCypherType: CypherType): Option[CypherType] = inputCypherType match {
     case CTNode(_, _) | CTRelationship(_, _) | CTMap(_) => Some(CTMap)
     case _ => None

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -603,7 +603,7 @@ final case class Divide(lhs: Expr, rhs: Expr) extends ArithmeticExpr {
 sealed trait PropagationTyp
 final case class ChildNullPropagation() extends PropagationTyp
 final case class NullabilityPropagation() extends PropagationTyp
-final case class FullNullabilityPropagtion() extends PropagationTyp
+final case class FullNullabilityPropagation() extends PropagationTyp
 
 
 sealed trait FunctionExpr extends Expr {
@@ -627,7 +627,7 @@ sealed trait FunctionExpr extends Expr {
        typePropagationFunction match {
          case Some(_: ChildNullPropagation) => childNullPropagatesTo(typ)
          case Some(_: NullabilityPropagation) => typ.asNullableAs(joinedCypherType)
-         case Some(_: FullNullabilityPropagtion) =>  if (exprs.exists(!_.cypherType.isNullable)) joinedCypherType.material else joinedCypherType.nullable
+         case Some(_: FullNullabilityPropagation) =>  if (exprs.exists(!_.cypherType.isNullable)) typ else typ.nullable
          case None => typ
         }
       case None =>
@@ -682,7 +682,7 @@ final case class ToId(expr: Expr) extends UnaryFunctionExpr {
 
   def signature(cypherType: CypherType): Option[CypherType] = cypherType match {
       case CTInteger | CTIdentity => Some(CTIdentity)
-      case x if x.subTypeOf(CTEntity) => Some(CTIdentity)
+      case x if x.subTypeOf(CTElement) => Some(CTIdentity)
       case _ => None
   }
 }
@@ -801,7 +801,7 @@ final case class BigDecimal(expr: Expr, precision: Long, scale: Long) extends Un
 final case class Coalesce(exprs: List[Expr]) extends FunctionExpr {
   override def nullInNullOut: Boolean = false
 
-  override def cypherType: CypherType = cypherType(Some(FullNullabilityPropagtion()))
+  override def cypherType: CypherType = cypherType(Some(FullNullabilityPropagation()))
 
   override def signature(inputCypherTypes: Vector[CypherType]): Option[CypherType] = Some(inputCypherTypes.reduceLeft(_ | _))
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -608,16 +608,13 @@ sealed trait FunctionExpr extends Expr {
   def exprs: List[Expr]
 }
 
-final case class MonotonicallyIncreasingId() extends FunctionExpr {
-
-  override def exprs: List[Expr] = List.empty
-
-  override def cypherType: CypherType = CTInteger
-}
-
 sealed trait NullaryFunctionExpr extends FunctionExpr {
 
   def exprs: List[Expr] = List.empty[Expr]
+}
+
+final case class MonotonicallyIncreasingId() extends NullaryFunctionExpr {
+  override def cypherType: CypherType = CTInteger
 }
 
 sealed trait UnaryFunctionExpr extends FunctionExpr {

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -962,7 +962,7 @@ case object Pi extends NullaryFunctionExpr {
 
 // Numeric functions
 
-final case class Abs(expr: Expr) extends UnaryMathematicalFunctionExpr(CTNumber)
+final case class Abs(expr: Expr) extends UnaryMathematicalFunctionExpr(expr.cypherType)
 
 final case class Ceil(expr: Expr) extends UnaryMathematicalFunctionExpr(CTInteger)
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -27,7 +27,7 @@
 package org.opencypher.okapi.ir.api.expr
 
 import org.opencypher.okapi.api.types._
-import org.opencypher.okapi.impl.exception.{IllegalArgumentException, UnsupportedOperationException}
+import org.opencypher.okapi.impl.exception.{IllegalArgumentException, NoSuitableSignatureForExpr}
 import org.opencypher.okapi.ir.api._
 import org.opencypher.okapi.ir.api.expr.FlattenOps._
 import org.opencypher.okapi.ir.api.expr.PrefixId.GraphIdPrefix
@@ -144,7 +144,7 @@ sealed trait TypeValidatedExpr extends Expr{
         }
       case None =>
         if (children.exists(_.cypherType == CTNull)) CTNull //todo: check corner cases (cases where no Propagation is specified)
-        else throw UnsupportedOperationException(s"Type signature ${getClass.getSimpleName}($joinedCypherType) is not supported.")
+        else throw NoSuitableSignatureForExpr(s"Type signature ${getClass.getSimpleName}($joinedCypherType) is not supported.")
     }
   }
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/Expr.scala
@@ -795,8 +795,12 @@ final case class BigDecimal(expr: Expr, precision: Long, scale: Long) extends Un
     throw IllegalArgumentException("Greater precision than scale", s"precision: $precision, scale: $scale")
   }
   override def propagationType: Option[PropagationType] = Some(NullabilityPropagation)
-  //todo: allowed cyphertypes?
-  def signature(cypherType: CypherType): Option[CypherType] = Some(CTBigDecimal(precision.toInt, scale.toInt)) }
+
+  def signature(cypherType: CypherType): Option[CypherType] = cypherType match {
+    case x if x.subTypeOf(CTNumber) => Some(CTBigDecimal(precision.toInt, scale.toInt))
+    case _ => None
+  }
+}
 
 final case class Coalesce(exprs: List[Expr]) extends FunctionExpr {
   override def nullInNullOut: Boolean = false

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/PropagationType.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/PropagationType.scala
@@ -1,0 +1,9 @@
+package org.opencypher.okapi.ir.api.expr
+
+
+sealed trait PropagationType
+case object NullOrAnyNullable extends PropagationType
+case object AnyNullable extends PropagationType
+case object AllNullable extends PropagationType
+case object InPropagation extends PropagationType //as In has no uniform PropagationType
+

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/PropagationType.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/PropagationType.scala
@@ -5,5 +5,3 @@ sealed trait PropagationType
 case object NullOrAnyNullable extends PropagationType
 case object AnyNullable extends PropagationType
 case object AllNullable extends PropagationType
-case object InPropagation extends PropagationType //as In has no uniform PropagationType
-

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/PropagationType.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/expr/PropagationType.scala
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2016-2019 "Neo4j Sweden, AB" [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
 package org.opencypher.okapi.ir.api.expr
 
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/functions/FunctionExtensions.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/functions/FunctionExtensions.scala
@@ -37,11 +37,6 @@ case object FunctionExtensions {
     LocalDateTime.name -> LocalDateTime,
     Date.name -> Date,
     Duration.name -> Duration,
-    ToBoolean.name -> ToBoolean,
-    ToString.name -> ToString,
-    Min.name -> Min,
-    Max.name -> Max,
-    Id.name -> Id
   ).map(p => p._1.toLowerCase -> p._2)
 
   def get(name: String): Option[Function with TypeSignatures] =
@@ -82,55 +77,10 @@ case object Date extends Function with TypeSignatures {
 
 case object Duration extends Function with TypeSignatures {
   override val name = "duration"
-
+  //todo: are these used?
   override val signatures = Vector(
     TypeSignature(argumentTypes = Vector(CTString), outputType = CTDuration),
     TypeSignature(argumentTypes = Vector(CTMap), outputType = CTDuration)
-  )
-}
-
-case object ToBoolean extends Function with TypeSignatures {
-  override val name = functions.ToBoolean.name
-
-  override val signatures = Vector(
-    TypeSignature(argumentTypes = Vector(CTString), outputType = CTBoolean),
-    TypeSignature(argumentTypes = Vector(CTBoolean), outputType = CTBoolean)
-  )
-}
-
-case object ToString extends Function with TypeSignatures {
-  override val name = functions.ToString.name
-
-  override val signatures = Vector(
-    TypeSignature(argumentTypes = Vector(CTFloat), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTInteger), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTBoolean), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTString), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTDuration), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTDate), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTTime), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTDateTime), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTLocalTime), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTLocalDateTime), outputType = CTString),
-    TypeSignature(argumentTypes = Vector(CTPoint), outputType = CTString)
-  )
-}
-
-case object Min extends AggregatingFunction with TypeSignatures {
-  override def name: String = functions.Min.name
-
-  override val signatures: Vector[TypeSignature] = Vector(
-    TypeSignature(argumentTypes = Vector(CTFloat), outputType = CTFloat),
-    TypeSignature(argumentTypes = Vector(CTInteger), outputType = CTInteger)
-  )
-}
-
-case object Max extends AggregatingFunction with TypeSignatures {
-  override def name: String = functions.Max.name
-
-  override val signatures: Vector[TypeSignature] = Vector(
-    TypeSignature(argumentTypes = Vector(CTFloat), outputType = CTFloat),
-    TypeSignature(argumentTypes = Vector(CTInteger), outputType = CTInteger)
   )
 }
 
@@ -139,11 +89,3 @@ object CTIdentity extends CypherType {
   override def toNeoTypeString: String = "IDENTITY"
 }
 
-case object Id extends Function with TypeSignatures {
-  def name: String = functions.Id.name
-
-  override val signatures: Vector[TypeSignature] = Vector(
-    TypeSignature(argumentTypes = Vector(CTNode), outputType = CTIdentity),
-    TypeSignature(argumentTypes = Vector(CTRelationship), outputType = CTIdentity)
-  )
-}

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/functions/FunctionExtensions.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/functions/FunctionExtensions.scala
@@ -26,62 +26,39 @@
  */
 package org.opencypher.okapi.ir.impl.parse.functions
 
-import org.opencypher.v9_0.expressions.{functions, _}
-import org.opencypher.v9_0.expressions.functions.{AggregatingFunction, Function}
+import org.opencypher.v9_0.expressions.functions.Function
 import org.opencypher.v9_0.util.symbols._
 
 case object FunctionExtensions {
 
-  private val mappings: Map[String, Function with TypeSignatures] = Map(
+  private val mappings: Map[String, Function] = Map(
     Timestamp.name -> Timestamp,
     LocalDateTime.name -> LocalDateTime,
     Date.name -> Date,
     Duration.name -> Duration,
   ).map(p => p._1.toLowerCase -> p._2)
 
-  def get(name: String): Option[Function with TypeSignatures] =
+  def get(name: String): Option[Function] =
     mappings.get(name.toLowerCase())
 
   def getOrElse(name: String, f: Function): Function =
     mappings.getOrElse(name.toLowerCase(), f)
 }
 
-case object Timestamp extends Function with TypeSignatures {
+case object Timestamp extends Function {
   override val name = "timestamp"
-
-  override val signatures = Vector(
-    TypeSignature(argumentTypes = Vector(), outputType = CTInteger)
-  )
 }
 
-case object LocalDateTime extends Function with TypeSignatures {
+case object LocalDateTime extends Function {
   override val name = "localdatetime"
-
-  override val signatures = Vector(
-    TypeSignature(argumentTypes = Vector(CTString), outputType = CTLocalDateTime),
-    TypeSignature(argumentTypes = Vector(CTMap), outputType = CTLocalDateTime),
-    TypeSignature(argumentTypes = Vector(), outputType = CTLocalDateTime)
-  )
 }
 
-case object Date extends Function with TypeSignatures {
+case object Date extends Function {
   override val name = "date"
-
-  override val signatures = Vector(
-    TypeSignature(argumentTypes = Vector(CTString), outputType = CTDate),
-    TypeSignature(argumentTypes = Vector(CTMap), outputType = CTDate),
-    TypeSignature(argumentTypes = Vector(), outputType = CTDate)
-
-  )
 }
 
-case object Duration extends Function with TypeSignatures {
+case object Duration extends Function {
   override val name = "duration"
-  //todo: are these used?
-  override val signatures = Vector(
-    TypeSignature(argumentTypes = Vector(CTString), outputType = CTDuration),
-    TypeSignature(argumentTypes = Vector(CTMap), outputType = CTDuration)
-  )
 }
 
 object CTIdentity extends CypherType {

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/functions/FunctionExtensions.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/parse/functions/FunctionExtensions.scala
@@ -35,8 +35,8 @@ case object FunctionExtensions {
     Timestamp.name -> Timestamp,
     LocalDateTime.name -> LocalDateTime,
     Date.name -> Date,
-    Duration.name -> Duration,
-  ).map(p => p._1.toLowerCase -> p._2)
+    Duration.name -> Duration)
+    .map(p => p._1.toLowerCase -> p._2)
 
   def get(name: String): Option[Function] =
     mappings.get(name.toLowerCase())

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/AndsTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/AndsTest.scala
@@ -26,7 +26,7 @@
  */
 package org.opencypher.okapi.ir.api.expr
 
-import org.opencypher.okapi.api.types.CTAny
+import org.opencypher.okapi.api.types.{CTAny, CTNode}
 import org.opencypher.okapi.ir.api.Label
 import org.opencypher.okapi.testing.BaseTestSuite
 import org.opencypher.okapi.testing.MatchHelper.equalWithTracing
@@ -34,7 +34,7 @@ import org.opencypher.okapi.testing.MatchHelper.equalWithTracing
 class AndsTest extends BaseTestSuite {
 
   test("unnests inner ands") {
-    val x = Var("x")()
+    val x = Var("x")(CTNode)
     val args: Set[Expr] = Set(Ands(TrueLit), HasLabel(x, Label("X")), Ands(Ands(Ands(FalseLit))))
 
     Ands(args) should equalWithTracing(Ands(Set(TrueLit, HasLabel(x, Label("X")), FalseLit)))

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
@@ -151,7 +151,7 @@ class ExprTest extends BaseTestSuite {
     }
 
     it("types Trim correctly") {
-      Trim(e).cypherType shouldBe CTInteger.nullable
+      Trim(e).cypherType shouldBe CTString.nullable
       an[UnsupportedOperationException] shouldBe thrownBy {Trim(datetime).cypherType}
     }
 

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
@@ -136,18 +136,18 @@ class ExprTest extends BaseTestSuite {
     it("types Avg correctly") {
       Avg(duration).cypherType shouldBe CTDuration
       Avg(number).cypherType shouldBe CTNumber
-      an[UnsupportedOperationException] shouldBe thrownBy {Avg(datetime).cypherType}
+      an[UnsupportedOperationException] shouldBe thrownBy {Avg(datetime)}
     }
 
     it("types Sum correctly") {
       Sum(duration).cypherType shouldBe CTDuration
       Sum(number).cypherType shouldBe CTNumber
-      an[UnsupportedOperationException] shouldBe thrownBy {Sum(datetime).cypherType}
+      an[UnsupportedOperationException] shouldBe thrownBy {Sum(datetime)}
     }
 
     it("types Size correctly") {
       Size(e).cypherType shouldBe CTInteger.nullable
-      an[UnsupportedOperationException] shouldBe thrownBy {Size(datetime).cypherType}
+      an[UnsupportedOperationException] shouldBe thrownBy {Size(datetime)}
     }
 
     it("types Trim correctly") {

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
@@ -152,13 +152,13 @@ class ExprTest extends BaseTestSuite {
 
     it("types Trim correctly") {
       Trim(e).cypherType shouldBe CTString.nullable
-      an[UnsupportedOperationException] shouldBe thrownBy {Trim(datetime).cypherType}
+      an[UnsupportedOperationException] shouldBe thrownBy {Trim(datetime)}
     }
 
     it("types Range correctly") {
       Range(d, d, None).cypherType shouldBe CTList(CTInteger)
       Range(d, d, Some(d)).cypherType
-      an[UnsupportedOperationException] shouldBe thrownBy {Range(e, d, None).cypherType}
+      an[UnsupportedOperationException] shouldBe thrownBy {Range(e, d, None)}
     }
 
     it("types TemporalInstants correctly") {

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
@@ -136,29 +136,29 @@ class ExprTest extends BaseTestSuite {
     it("types Avg correctly") {
       Avg(duration).cypherType shouldBe CTDuration
       Avg(number).cypherType shouldBe CTNumber
-      an[UnsupportedOperationException] shouldBe thrownBy {Avg(datetime)}
+      an[NoSuitableSignatureForExpr] shouldBe thrownBy {Avg(datetime)}
     }
 
     it("types Sum correctly") {
       Sum(duration).cypherType shouldBe CTDuration
       Sum(number).cypherType shouldBe CTNumber
-      an[UnsupportedOperationException] shouldBe thrownBy {Sum(datetime)}
+      an[NoSuitableSignatureForExpr] shouldBe thrownBy {Sum(datetime)}
     }
 
     it("types Size correctly") {
       Size(e).cypherType shouldBe CTInteger.nullable
-      an[UnsupportedOperationException] shouldBe thrownBy {Size(datetime)}
+      an[NoSuitableSignatureForExpr] shouldBe thrownBy {Size(datetime)}
     }
 
     it("types Trim correctly") {
       Trim(e).cypherType shouldBe CTString.nullable
-      an[UnsupportedOperationException] shouldBe thrownBy {Trim(datetime)}
+      an[NoSuitableSignatureForExpr] shouldBe thrownBy {Trim(datetime)}
     }
 
     it("types Range correctly") {
       Range(d, d, None).cypherType shouldBe CTList(CTInteger)
       Range(d, d, Some(d)).cypherType
-      an[UnsupportedOperationException] shouldBe thrownBy {Range(e, d, None)}
+      an[NoSuitableSignatureForExpr] shouldBe thrownBy {Range(e, d, None)}
     }
 
     it("types TemporalInstants correctly") {

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/api/expr/ExprTest.scala
@@ -144,6 +144,27 @@ class ExprTest extends BaseTestSuite {
       Sum(number).cypherType shouldBe CTNumber
       an[UnsupportedOperationException] shouldBe thrownBy {Sum(datetime).cypherType}
     }
-  }
 
+    it("types Size correctly") {
+      Size(e).cypherType shouldBe CTInteger.nullable
+      an[UnsupportedOperationException] shouldBe thrownBy {Size(datetime).cypherType}
+    }
+
+    it("types Trim correctly") {
+      Trim(e).cypherType shouldBe CTInteger.nullable
+      an[UnsupportedOperationException] shouldBe thrownBy {Trim(datetime).cypherType}
+    }
+
+    it("types Range correctly") {
+      Range(d, d, None).cypherType shouldBe CTList(CTInteger)
+      Range(d, d, Some(d)).cypherType
+      an[UnsupportedOperationException] shouldBe thrownBy {Range(e, d, None).cypherType}
+    }
+
+    it("types TemporalInstants correctly") {
+      Date(Some(e)).cypherType shouldBe CTDate.nullable
+      Duration(e).cypherType shouldBe CTDuration.nullable
+      LocalDateTime(Some(e)).cypherType shouldBe CTLocalDateTime.nullable
+    }
+  }
 }


### PR DESCRIPTION
Adds checks, whether the cypher-types of the argument-expressions for an expression are valid.
Thus f.i. `Trim(Var('e')(CTInteger)).cyphertype` will now fail.

Also some redundancy could get eliminated in the process