### PR TITLE
Upgrade to Spark 2.4.3

### DIFF
--- a/build.params.gradle
+++ b/build.params.gradle
@@ -18,7 +18,7 @@ ext {
             neo4j     : [driver : '1.7.2',
                          harness: '3.4.10'],
 
-            spark     : '2.4.0',
+            spark     : '2.4.3',
             hadoop    : '2.7.0',
             fastparse : '2.1.0',
             upickle   : '0.7.1',

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/CensusHiveExample.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/CensusHiveExample.scala
@@ -94,7 +94,7 @@ object CensusHiveExample extends App {
       // This is to avoid creating a local HIVE "metastore_db" on disk which needs to be cleaned up before each run,
       // e.g. avoids database and table already exists exceptions on re-runs - not to be used for production.
       // -----------------------------------------------------------------------------------------------------------
-      ("javax.jdo.option.ConnectionURL", "jdbc:derby:memory:hms;create=true"),
+      ("javax.jdo.option.ConnectionURL", s"jdbc:derby:memory:;databaseName=metastore_db;create=true"),
       ("javax.jdo.option.ConnectionDriverName", "org.apache.derby.jdbc.EmbeddedDriver"),
       // ------------------------------------------------------------------------------------------------------------
       // An alternative way of enabling Spark Hive Support (e.g. you could use enableHiveSupport on the SparkSession)

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/CypherSQLRoundtripExample.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/CypherSQLRoundtripExample.scala
@@ -29,7 +29,7 @@ package org.opencypher.morpheus.examples
 
 import org.opencypher.morpheus.api.{GraphSources, MorpheusSession}
 import org.opencypher.morpheus.impl.MorpheusConverters._
-import org.opencypher.morpheus.util.App
+import org.opencypher.morpheus.util.{App, HiveUtils}
 import org.opencypher.okapi.api.graph.Namespace
 
 /**
@@ -40,7 +40,7 @@ import org.opencypher.okapi.api.graph.Namespace
   */
 object CypherSQLRoundtripExample extends App {
   // 1) Create Morpheus session
-  implicit val morpheus: MorpheusSession = MorpheusSession.local()
+  implicit val morpheus: MorpheusSession = MorpheusSession.local(HiveUtils.hiveExampleSettings: _*)
 
   // 2) Register a file based data source at the session
   //    It contains a purchase network graph called 'products'

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/HiveSupportExample.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/HiveSupportExample.scala
@@ -27,24 +27,14 @@
 // tag::full-example[]
 package org.opencypher.morpheus.examples
 
-import java.util.UUID
-
-import org.apache.spark.sql.SparkSession
 import org.opencypher.morpheus.api.io.util.HiveTableName
 import org.opencypher.morpheus.api.{GraphSources, MorpheusSession}
-import org.opencypher.morpheus.util.App
+import org.opencypher.morpheus.util.{App, HiveUtils}
 import org.opencypher.okapi.api.graph.{GraphName, Node}
 
 object HiveSupportExample extends App {
 
-  val sparkSession = SparkSession
-    .builder()
-    .master("local[*]")
-    .enableHiveSupport()
-    .appName(s"morpheus-local-${UUID.randomUUID()}")
-    .getOrCreate()
-    sparkSession.sparkContext.setLogLevel("error")
-  implicit val session = MorpheusSession.create(sparkSession)
+  implicit val session: MorpheusSession = MorpheusSession.local(HiveUtils.hiveExampleSettings: _*)
 
   val hiveDatabaseName = "socialNetwork"
   session.sparkSession.sql(s"DROP DATABASE IF EXISTS $hiveDatabaseName CASCADE")

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/LdbcHiveExample.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/examples/LdbcHiveExample.scala
@@ -35,7 +35,7 @@ import org.opencypher.morpheus.api.io.sql.SqlDataSourceConfig.Hive
 import org.opencypher.morpheus.api.{GraphSources, MorpheusSession}
 import org.opencypher.morpheus.testing.utils.FileSystemUtils._
 import org.opencypher.morpheus.util.LdbcUtil._
-import org.opencypher.morpheus.util.{App, LdbcUtil}
+import org.opencypher.morpheus.util.{App, HiveUtils, LdbcUtil}
 import org.opencypher.okapi.api.graph.Namespace
 
 /**
@@ -55,7 +55,7 @@ object LdbcHiveExample extends App {
   val datasourceName = "warehouse"
   val database = "LDBC"
 
-  implicit val session: MorpheusSession = MorpheusSession.local(CATALOG_IMPLEMENTATION.key -> "hive")
+  implicit val session: MorpheusSession = MorpheusSession.local(HiveUtils.hiveExampleSettings: _*)
   implicit val spark: SparkSession = session.sparkSession
 
   val csvFiles = new File(resource("csv/").getFile).list()

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/integration/Customer360IntegrationDemo.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/integration/Customer360IntegrationDemo.scala
@@ -29,11 +29,10 @@ package org.opencypher.morpheus.integration
 import java.net.URI
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
-import org.opencypher.morpheus.api.{GraphSources, MorpheusSession}
 import org.opencypher.morpheus.api.io.neo4j.sync.Neo4jGraphMerge
-import org.opencypher.morpheus.util.App
+import org.opencypher.morpheus.api.{GraphSources, MorpheusSession}
+import org.opencypher.morpheus.util.{App, HiveUtils}
 import org.opencypher.okapi.api.graph.Namespace
 import org.opencypher.okapi.neo4j.io.MetaLabelSupport._
 import org.opencypher.okapi.neo4j.io.Neo4jConfig
@@ -54,13 +53,9 @@ object Customer360IntegrationDemo extends App {
 
   implicit val resourceFolder: String = "/customer-interactions"
 
-  implicit val spark: SparkSession = SparkSession
-    .builder()
-    .master("local[*]")
-    .enableHiveSupport()
-    .getOrCreate()
+  implicit val session: MorpheusSession = MorpheusSession.local(HiveUtils.hiveExampleSettings: _*)
 
-  implicit val session: MorpheusSession = MorpheusSession.local(CATALOG_IMPLEMENTATION.key -> "hive")
+  implicit val spark: SparkSession = session.sparkSession
 
   val inputSchema: StructType = StructType(Seq(
     StructField("interactionId", LongType, nullable = false),

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/util/HiveUtils.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/util/HiveUtils.scala
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2016-2019 "Neo4j Sweden, AB" [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Attribution Notice under the terms of the Apache License 2.0
+ *
+ * This work was created by the collective efforts of the openCypher community.
+ * Without limiting the terms of Section 6, any Derivative Work that is not
+ * approved by the public consensus process of the openCypher Implementers Group
+ * should not be described as “Cypher” (and Cypher® is a registered trademark of
+ * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+ * proposals for change that have been documented or implemented should only be
+ * described as "implementation extensions to Cypher" or as "proposed changes to
+ * Cypher that are not yet approved by the openCypher community".
+ */
 package org.opencypher.morpheus.util
 
 import java.io.File

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/util/HiveUtils.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/util/HiveUtils.scala
@@ -1,0 +1,29 @@
+package org.opencypher.morpheus.util
+
+import java.io.File
+
+import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
+
+object HiveUtils {
+  def hiveExampleSettings: Seq[(String, String)] = {
+    val sparkWarehouseDir = new File(s"spark-warehouse_${System.currentTimeMillis}").getAbsolutePath
+    Seq(
+      // ------------------------------------------------------------------------
+      // Create a new unique local spark warehouse dir for every run - idempotent
+      // ------------------------------------------------------------------------
+      ("spark.sql.warehouse.dir", sparkWarehouseDir),
+      // -----------------------------------------------------------------------------------------------------------
+      // Create an in-memory Hive Metastore (only Derby supported for this mode)
+      // This is to avoid creating a local HIVE "metastore_db" on disk which needs to be cleaned up before each run,
+      // e.g. avoids database and table already exists exceptions on re-runs - not to be used for production.
+      // -----------------------------------------------------------------------------------------------------------
+      ("javax.jdo.option.ConnectionURL", s"jdbc:derby:memory:;databaseName=metastore_db;create=true"),
+      ("javax.jdo.option.ConnectionDriverName", "org.apache.derby.jdbc.EmbeddedDriver"),
+      // ------------------------------------------------------------------------------------------------------------
+      // An alternative way of enabling Spark Hive Support (e.g. you could use enableHiveSupport on the SparkSession)
+      // ------------------------------------------------------------------------------------------------------------
+      ("hive.metastore.warehouse.dir", s"warehouse_${System.currentTimeMillis}"),
+      (CATALOG_IMPLEMENTATION.key, "hive") // Enable hive
+    )
+  }
+}

--- a/morpheus-examples/src/main/scala/org/opencypher/morpheus/util/HiveUtils.scala
+++ b/morpheus-examples/src/main/scala/org/opencypher/morpheus/util/HiveUtils.scala
@@ -43,7 +43,7 @@ object HiveUtils {
       // This is to avoid creating a local HIVE "metastore_db" on disk which needs to be cleaned up before each run,
       // e.g. avoids database and table already exists exceptions on re-runs - not to be used for production.
       // -----------------------------------------------------------------------------------------------------------
-      ("javax.jdo.option.ConnectionURL", s"jdbc:derby:memory:;databaseName=metastore_db;create=true"),
+      ("javax.jdo.option.ConnectionURL", "jdbc:derby:memory:;databaseName=metastore_db;create=true"),
       ("javax.jdo.option.ConnectionDriverName", "org.apache.derby.jdbc.EmbeddedDriver"),
       // ------------------------------------------------------------------------------------------------------------
       // An alternative way of enabling Spark Hive Support (e.g. you could use enableHiveSupport on the SparkSession)

--- a/morpheus-testing/src/main/scala/org/opencypher/morpheus/testing/TestSparkSession.scala
+++ b/morpheus-testing/src/main/scala/org/opencypher/morpheus/testing/TestSparkSession.scala
@@ -67,9 +67,9 @@ object TestSparkSession {
     // Writes spark-warehouse folder to local temp folder
     conf.set("spark.sql.warehouse.dir", s"${System.getProperty("java.io.tmpdir")}${File.separator}spark-warehouse-${System.nanoTime()}")
     // Store Hive MetaStore (derby) in memory only
-    conf.set("javax.jdo.option.ConnectionURL", "jdbc:derby:memory:hms;create=true")
+    conf.set("javax.jdo.option.ConnectionURL", s"jdbc:derby:memory:;databaseName=metastore_db;create=true")
     conf.set("javax.jdo.option.ConnectionDriverName", "org.apache.derby.jdbc.EmbeddedDriver")
-
+    conf.set("hive.metastore.warehouse.dir", s"${System.getProperty("java.io.tmpdir")}${File.separator}hive-warehouse-${System.nanoTime()}")
     //
     // If this is slow, you might be hitting: http://bugs.java.com/view_bug.do?bug_id=8077102
     //

--- a/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/table/Table.scala
+++ b/okapi-relational/src/main/scala/org/opencypher/okapi/relational/api/table/Table.scala
@@ -137,12 +137,12 @@ trait Table[T <: Table[T]] extends CypherTable {
   def distinct: T
 
   /**
-    * Convenience operator for select and distinct.
+    * Returns a table where each row is unique with regard to the specified columns
     *
-    * @param cols columns to select and perform distinct on.
+    * @param cols columns to consider when comparing rows
     * @return table containing the specific columns and distinct rows
     */
-  def distinct(cols: String*): T = select(cols: _*).distinct
+  def distinct(cols: String*): T
 
   /**
     * Groups the rows within the table by the given query variables. Additionally a set of aggregations can be performed


### PR DESCRIPTION
fixes #889

Spark 2.4.3 fixes a bug where creating a Dataframe from `RDD[Row]` resulted in an Error