### PR TITLE
Support durations in aggregation-functions

### DIFF
--- a/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/SparkSQLExprMapper.scala
+++ b/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/SparkSQLExprMapper.scala
@@ -35,7 +35,7 @@ import org.opencypher.morpheus.impl.convert.SparkConversions._
 import org.opencypher.morpheus.impl.expressions.AddPrefix._
 import org.opencypher.morpheus.impl.expressions.EncodeLong._
 import org.opencypher.morpheus.impl.temporal.TemporalConversions._
-import org.opencypher.morpheus.impl.temporal.TemporalUdfs
+import org.opencypher.morpheus.impl.temporal.{TemporalUdafs, TemporalUdfs}
 import org.opencypher.okapi.api.types._
 import org.opencypher.okapi.api.value.CypherValue.CypherMap
 import org.opencypher.okapi.impl.exception._
@@ -348,11 +348,26 @@ object SparkSQLExprMapper {
           else collect_list(child0)
 
         case CountStar => count(ONE_LIT)
-        case _: Avg => avg(child0)
-
-        case _: Max => max(child0)
-        case _: Min => min(child0)
-        case _: Sum => sum(child0)
+        case _: Avg =>
+          expr.cypherType match {
+            case CTDuration => TemporalUdafs.durationAvg(child0)
+            case _ => avg(child0)
+          }
+        case _: Max =>
+          expr.cypherType match {
+            case CTDuration => TemporalUdafs.durationMax(child0)
+            case _ => max(child0)
+          }
+        case _: Min =>
+          expr.cypherType match {
+            case CTDuration => TemporalUdafs.durationMin(child0)
+            case _ => min(child0)
+          }
+        case _: Sum =>
+          expr.cypherType match {
+            case CTDuration => TemporalUdafs.durationSum(child0)
+            case _ => sum(child0)
+          }
 
 
         case BigDecimal(_, precision, scale) =>

--- a/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdafs.scala
+++ b/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdafs.scala
@@ -1,0 +1,123 @@
+/**
+  * Copyright (c) 2016-2019 "Neo4j Sweden, AB" [https://neo4j.com]
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  *
+  * Attribution Notice under the terms of the Apache License 2.0
+  *
+  * This work was created by the collective efforts of the openCypher community.
+  * Without limiting the terms of Section 6, any Derivative Work that is not
+  * approved by the public consensus process of the openCypher Implementers Group
+  * should not be described as “Cypher” (and Cypher® is a registered trademark of
+  * Neo4j Inc.) or as "openCypher". Extensions by implementers or prototypes or
+  * proposals for change that have been documented or implemented should only be
+  * described as "implementation extensions to Cypher" or as "proposed changes to
+  * Cypher that are not yet approved by the openCypher community".
+  */
+package org.opencypher.morpheus.impl.temporal
+
+import org.apache.logging.log4j.scala.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
+import org.apache.spark.sql.types.{CalendarIntervalType, DataType, LongType, StructField, StructType}
+import org.apache.spark.unsafe.types.CalendarInterval
+import org.opencypher.okapi.impl.temporal.TemporalConstants
+
+object TemporalUdafs extends Logging{
+
+  def greaterThan(interval1 : CalendarInterval, interval2 : CalendarInterval): Boolean =
+    if(avgSeconds(interval1) >= avgSeconds(interval2)) true else false
+
+  //similar to comparison in neo4j (not the same as CalenderInterval only differs between seconds and months)
+  def avgSeconds(interval : CalendarInterval): Double = {
+    interval.months * TemporalConstants.AVG_DAYS_PER_MONTH + interval.microseconds / CalendarInterval.MICROS_PER_SECOND
+  }
+
+  abstract class SimpleDurationAggregation(aggrName : String) extends UserDefinedAggregateFunction {
+    override def inputSchema: StructType = StructType(Array(StructField("duration", CalendarIntervalType)))
+    override def bufferSchema: StructType = StructType(Array(StructField(aggrName, CalendarIntervalType)))
+    override def dataType: DataType = CalendarIntervalType
+    override def deterministic: Boolean = true
+    override def initialize(buffer: MutableAggregationBuffer): Unit = {
+      buffer(0) = new CalendarInterval(0, 0L)
+    }
+    override def evaluate(buffer: Row): Any = buffer.getAs[CalendarInterval](0)
+  }
+
+  class DurationSum extends SimpleDurationAggregation("sum") {
+    override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+      buffer(0) = buffer.getAs[CalendarInterval](0).add(input.getAs[CalendarInterval](0))
+    }
+    override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+      buffer1(0) = buffer2.getAs[CalendarInterval](0).add(buffer1.getAs[CalendarInterval](0))
+    }
+  }
+
+  class DurationMax extends SimpleDurationAggregation("max"){
+    override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+      val currMaxInterval = buffer.getAs[CalendarInterval](0)
+      val inputInterval = input.getAs[CalendarInterval](0)
+      buffer(0) = if(greaterThan(currMaxInterval, inputInterval)) currMaxInterval else inputInterval
+    }
+    override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+      val interval1 = buffer1.getAs[CalendarInterval](0)
+      val interval2 = buffer2.getAs[CalendarInterval](0)
+      buffer1(0) = if(greaterThan(interval1, interval2)) interval1 else interval2
+    }
+  }
+
+  class DurationMin extends SimpleDurationAggregation("min"){
+    override def initialize(buffer: MutableAggregationBuffer): Unit = {
+      buffer(0) = new CalendarInterval(Integer.MAX_VALUE, Long.MaxValue)
+    }
+    override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+      val currMinInterval = buffer.getAs[CalendarInterval](0)
+      val inputInterval = input.getAs[CalendarInterval](0)
+      buffer(0) = if(greaterThan(inputInterval, currMinInterval)) currMinInterval else inputInterval
+    }
+    override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+      val interval1 = buffer1.getAs[CalendarInterval](0)
+      val interval2 = buffer2.getAs[CalendarInterval](0)
+      buffer1(0) = if(greaterThan(interval2, interval1)) interval1 else interval2
+    }
+  }
+
+  class DurationAvg extends UserDefinedAggregateFunction{
+    override def inputSchema: StructType = StructType(Array(StructField("duration", CalendarIntervalType)))
+    override def bufferSchema: StructType = StructType(Array(StructField("sum", CalendarIntervalType), StructField("cnt", LongType)))
+    override def dataType: DataType = CalendarIntervalType
+    override def deterministic: Boolean = true
+    override def initialize(buffer: MutableAggregationBuffer): Unit = {
+      buffer(0) = new CalendarInterval(0, 0L)
+      buffer(1) = 0L
+    }
+    override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
+      buffer(0) = buffer.getAs[CalendarInterval](0).add(input.getAs[CalendarInterval](0))
+      buffer(1) = buffer.getLong(1) + 1
+    }
+    override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
+      buffer1(0) = buffer2.getAs[CalendarInterval](0).add(buffer1.getAs[CalendarInterval](0))
+      buffer1(1) = buffer1.getLong(1) + buffer2.getLong(1)
+    }
+    override def evaluate(buffer: Row): Any = {
+      val sumInterval = buffer.getAs[CalendarInterval](0)
+      val cnt = buffer.getLong(1)
+      new CalendarInterval((sumInterval.months / cnt).toInt, sumInterval.microseconds / cnt)
+    }
+  }
+
+  val durationSum = new DurationSum()
+  val durationAvg = new DurationAvg()
+  val durationMin = new DurationMin()
+  val durationMax = new DurationMax()
+}

--- a/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdafs.scala
+++ b/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdafs.scala
@@ -34,9 +34,9 @@ import org.apache.spark.unsafe.types.CalendarInterval
 import org.opencypher.okapi.impl.temporal.TemporalConstants
 import org.opencypher.morpheus.impl.temporal.TemporalConversions._
 
-object TemporalUdafs extends Logging{
+object TemporalUdafs extends Logging {
 
-  abstract class SimpleDurationAggregation(aggrName : String) extends UserDefinedAggregateFunction {
+  abstract class SimpleDurationAggregation(aggrName: String) extends UserDefinedAggregateFunction {
     override def inputSchema: StructType = StructType(Array(StructField("duration", CalendarIntervalType)))
     override def bufferSchema: StructType = StructType(Array(StructField(aggrName, CalendarIntervalType)))
     override def dataType: DataType = CalendarIntervalType
@@ -56,36 +56,36 @@ object TemporalUdafs extends Logging{
     }
   }
 
-  class DurationMax extends SimpleDurationAggregation("max"){
+  class DurationMax extends SimpleDurationAggregation("max") {
     override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
       val currMaxInterval = buffer.getAs[CalendarInterval](0)
       val inputInterval = input.getAs[CalendarInterval](0)
-      buffer(0) = if(currMaxInterval.toDuration.compare(inputInterval.toDuration) >= 0) currMaxInterval else inputInterval
+      buffer(0) = if (currMaxInterval.toDuration.compare(inputInterval.toDuration) >= 0) currMaxInterval else inputInterval
     }
     override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
       val interval1 = buffer1.getAs[CalendarInterval](0)
       val interval2 = buffer2.getAs[CalendarInterval](0)
-      buffer1(0) = if(interval1.toDuration.compare(interval2.toDuration) >= 0) interval1 else interval2
+      buffer1(0) = if (interval1.toDuration.compare(interval2.toDuration) >= 0) interval1 else interval2
     }
   }
 
-  class DurationMin extends SimpleDurationAggregation("min"){
+  class DurationMin extends SimpleDurationAggregation("min") {
     override def initialize(buffer: MutableAggregationBuffer): Unit = {
       buffer(0) = new CalendarInterval(Integer.MAX_VALUE, Long.MaxValue)
     }
     override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
       val currMinInterval = buffer.getAs[CalendarInterval](0)
       val inputInterval = input.getAs[CalendarInterval](0)
-      buffer(0) = if(inputInterval.toDuration.compare(currMinInterval.toDuration) >= 0) currMinInterval else inputInterval
+      buffer(0) = if (inputInterval.toDuration.compare(currMinInterval.toDuration) >= 0) currMinInterval else inputInterval
     }
     override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
       val interval1 = buffer1.getAs[CalendarInterval](0)
       val interval2 = buffer2.getAs[CalendarInterval](0)
-      buffer1(0) = if(interval2.toDuration.compare(interval1.toDuration) >= 0) interval1 else interval2
+      buffer1(0) = if (interval2.toDuration.compare(interval1.toDuration) >= 0) interval1 else interval2
     }
   }
 
-  class DurationAvg extends UserDefinedAggregateFunction{
+  class DurationAvg extends UserDefinedAggregateFunction {
     override def inputSchema: StructType = StructType(Array(StructField("duration", CalendarIntervalType)))
     override def bufferSchema: StructType = StructType(Array(StructField("sum", CalendarIntervalType), StructField("cnt", LongType)))
     override def dataType: DataType = CalendarIntervalType

--- a/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdfs.scala
+++ b/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdfs.scala
@@ -30,10 +30,8 @@ import java.sql.{Date, Timestamp}
 import java.time.temporal.{ChronoField, IsoFields, TemporalField}
 
 import org.apache.logging.log4j.scala.Logging
-import org.apache.spark.sql.Row
-import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction, UserDefinedFunction}
+import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import org.apache.spark.sql.types.{CalendarIntervalType, DataType, LongType, StructField, StructType}
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.opencypher.okapi.impl.exception.UnsupportedOperationException
 
@@ -121,7 +119,7 @@ object TemporalUdfs extends Logging {
       } else {
         val days = duration.microseconds / CalendarInterval.MICROS_PER_DAY
         // Note: in cypher days (and weeks) make up their own group, thus we have to exclude them for all values < day
-        val daysInMicros =  days * CalendarInterval.MICROS_PER_DAY
+        val daysInMicros = days * CalendarInterval.MICROS_PER_DAY
 
         val l: Long = accessor match {
           case "years" => duration.months / 12
@@ -129,20 +127,20 @@ object TemporalUdfs extends Logging {
           case "months" => duration.months
           case "weeks" => duration.microseconds / CalendarInterval.MICROS_PER_DAY / 7
           case "days" => duration.microseconds / CalendarInterval.MICROS_PER_DAY
-          case "hours" => (duration.microseconds - daysInMicros ) / CalendarInterval.MICROS_PER_HOUR
-          case "minutes" => (duration.microseconds - daysInMicros ) / CalendarInterval.MICROS_PER_MINUTE
-          case "seconds" => (duration.microseconds - daysInMicros ) / CalendarInterval.MICROS_PER_SECOND
-          case "milliseconds" => (duration.microseconds - daysInMicros ) / CalendarInterval.MICROS_PER_MILLI
+          case "hours" => (duration.microseconds - daysInMicros) / CalendarInterval.MICROS_PER_HOUR
+          case "minutes" => (duration.microseconds - daysInMicros) / CalendarInterval.MICROS_PER_MINUTE
+          case "seconds" => (duration.microseconds - daysInMicros) / CalendarInterval.MICROS_PER_SECOND
+          case "milliseconds" => (duration.microseconds - daysInMicros) / CalendarInterval.MICROS_PER_MILLI
           case "microseconds" => duration.microseconds - daysInMicros
 
           case "quartersofyear" => (duration.months / 3) % 4
           case "monthsofquarter" => duration.months % 3
           case "monthsofyear" => duration.months % 12
           case "daysofweek" => (duration.microseconds / CalendarInterval.MICROS_PER_DAY) % 7
-          case "minutesofhour" => ((duration.microseconds  - daysInMicros )/ CalendarInterval.MICROS_PER_MINUTE) % 60
-          case "secondsofminute" => ((duration.microseconds - daysInMicros ) / CalendarInterval.MICROS_PER_SECOND) % 60
-          case "millisecondsofsecond" => ((duration.microseconds - daysInMicros ) / CalendarInterval.MICROS_PER_MILLI) % 1000
-          case "microsecondsofsecond" => (duration.microseconds - daysInMicros ) % 1000000
+          case "minutesofhour" => ((duration.microseconds - daysInMicros) / CalendarInterval.MICROS_PER_MINUTE) % 60
+          case "secondsofminute" => ((duration.microseconds - daysInMicros) / CalendarInterval.MICROS_PER_SECOND) % 60
+          case "millisecondsofsecond" => ((duration.microseconds - daysInMicros) / CalendarInterval.MICROS_PER_MILLI) % 1000
+          case "microsecondsofsecond" => (duration.microseconds - daysInMicros) % 1000000
 
           case other => throw UnsupportedOperationException(s"Unknown Duration accessor: $other")
         }

--- a/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdfs.scala
+++ b/morpheus-spark-cypher/src/main/scala/org/opencypher/morpheus/impl/temporal/TemporalUdfs.scala
@@ -30,8 +30,10 @@ import java.sql.{Date, Timestamp}
 import java.time.temporal.{ChronoField, IsoFields, TemporalField}
 
 import org.apache.logging.log4j.scala.Logging
-import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction, UserDefinedFunction}
 import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types.{CalendarIntervalType, DataType, LongType, StructField, StructType}
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.opencypher.okapi.impl.exception.UnsupportedOperationException
 

--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/AggregationTests.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/AggregationTests.scala
@@ -126,12 +126,11 @@ class AggregationTests extends MorpheusTestSuite with ScanGraphInit {
       ))
     }
 
-    //todo: cypher should allow avg on durations, but spark does not support avg on durations (calendarintervals)
-    ignore("avg on durations") {
-      val result = morpheus.graphs.empty.cypher("UNWIND [duration('P1DT12H'), duration('P1DT200H')] AS d RETURN AVG(d) as res")
+    it("avg on durations") {
+      val result = morpheus.graphs.empty.cypher("UNWIND [duration('P1DT12H'), duration('P1DT20H')] AS d RETURN AVG(d) as res")
 
       result.records.toMaps should equal(Bag(
-        CypherMap("res" -> Duration(days = 1, hours = 12))
+        CypherMap("res" -> Duration(days = 1, hours = 16))
       ))
     }
   }
@@ -366,8 +365,7 @@ class AggregationTests extends MorpheusTestSuite with ScanGraphInit {
       ))
     }
 
-    //todo: spark does not support min on durations (calendarintervals)
-    ignore("min on durations") {
+    it("min on durations") {
       val result = morpheus.graphs.empty.cypher("UNWIND [duration('P1DT12H'), duration('P1DT200H')] AS d RETURN MIN(d) as res")
 
       result.records.toMaps should equal(Bag(
@@ -472,12 +470,11 @@ class AggregationTests extends MorpheusTestSuite with ScanGraphInit {
       ))
     }
 
-    //todo: spark does not support max on durations (calendarintervals)
-    ignore("max on durations") {
-      val result = morpheus.graphs.empty.cypher("UNWIND [duration('P1DT12H'), duration('P1DT200H')] AS d RETURN MAX(d) as res")
+    it("max on durations") {
+      val result = morpheus.graphs.empty.cypher("UNWIND [duration('P10DT12H'), duration('P1DT24H')] AS d RETURN MAX(d) as res")
 
       result.records.toMaps should equal(Bag(
-        CypherMap("res" -> Duration(days = 1, hours = 200))
+        CypherMap("res" -> Duration(days = 10, hours = 12))
       ))
     }
 
@@ -584,12 +581,11 @@ class AggregationTests extends MorpheusTestSuite with ScanGraphInit {
       ))
     }
 
-    //todo: cypher should sum over durations, but spark does not support sum over durations (calendarintervals)
-    ignore("sum on durations") {
-      val result = morpheus.graphs.empty.cypher("UNWIND [duration('P1DT12H'), duration('P1DT200H')] AS d RETURN SUM(d) as res")
+    it("sum on durations") {
+      val result = morpheus.graphs.empty.cypher("UNWIND [duration('P1DT12H'), duration('P1DT24H')] AS d RETURN SUM(d) as res")
 
       result.records.toMaps should equal(Bag(
-        CypherMap("res" -> Duration(days = 2, hours = 12))
+        CypherMap("res" -> Duration(days = 3, hours = 12))
       ))
     }
   }


### PR DESCRIPTION
Cypher supports the aggregation of `Durations`, however Spark does not support the aggregation of `CalendarIntervals`.

This will allow the aggregation of `CalendarIntervals` via user-defined aggregation functions (_udafs_).
