### PR TITLE
Restrict possible patterns in Construct

### DIFF
--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/MultipleGraphTests.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/impl/acceptance/MultipleGraphTests.scala
@@ -982,4 +982,43 @@ class MultipleGraphTests extends MorpheusTestSuite with ScanGraphInit {
 
     an[SchemaException] should be thrownBy morpheus.cypher("CONSTRUCT ON g1, g2 RETURN GRAPH")
   }
+
+  it("should implicit clone a relationship #1") {
+    val query =
+      """|MATCH (a)-[r:HAS_SIMILAR_NAME]->(b)
+         |CONSTRUCT
+         |  CREATE (a)-[r]->(b)
+         |RETURN GRAPH""".stripMargin
+    val result = testGraphRels.cypher(query)
+    result.graph.cypher("MATCH ()-[r]->() RETURN type(r) as type").records.iterator.toBag should equal(Bag(
+      CypherMap("type" -> "HAS_SIMILAR_NAME")
+    ))
+  }
+
+  it("should implicit clone a relationship #2") {
+    val query =
+      """|MATCH (a)-[r:HAS_SIMILAR_NAME]->(b)
+         |WITH a,r,b
+         |CONSTRUCT
+         |  CREATE (a)-[r]->(b)
+         |RETURN GRAPH""".stripMargin
+    val result = testGraphRels.cypher(query)
+    result.graph.cypher("MATCH ()-[r]->() RETURN type(r) as type").records.iterator.toBag should equal(Bag(
+      CypherMap("type" -> "HAS_SIMILAR_NAME")
+    ))
+  }
+
+  it("should implicit clone a relationship #3") {
+    val query =
+      """|MATCH (a)-[r:HAS_SIMILAR_NAME]->(b)
+         |WITH a,r,b
+         |CONSTRUCT
+         |  CLONE a AS x, b AS y
+         |  CREATE (x)-[r]->(y)
+         |RETURN GRAPH""".stripMargin
+    val result = testGraphRels.cypher(query)
+    result.graph.cypher("MATCH ()-[r]->() RETURN type(r) as type").records.iterator.toBag should equal(Bag(
+      CypherMap("type" -> "HAS_SIMILAR_NAME")
+    ))
+  }
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/pattern/Connection.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/pattern/Connection.scala
@@ -162,3 +162,12 @@ final case class UndirectedVarLengthRelationship(edgeType: CTRelationship, endpo
     case _ => false
   }
 }
+
+case object ConnectionCopier {
+  def copy(con: Connection, endpoints: DifferentEndpoints) : Connection = con match {
+    case r: DirectedRelationship => DirectedRelationship(endpoints, r.semanticDirection)
+    case r: DirectedVarLengthRelationship => r.copy(endpoints = endpoints)
+    case _: UndirectedRelationship | _: CyclicRelationship => UndirectedRelationship(endpoints)
+    case r: UndirectedVarLengthRelationship => r.copy(endpoints = endpoints)
+  }
+}

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/util/FreshVariableNamer.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/api/util/FreshVariableNamer.scala
@@ -31,8 +31,12 @@ import org.opencypher.okapi.ir.api.expr.Var
 
 object FreshVariableNamer {
   val PREFIX = "  "
+  val NAME = "FRESH_VAR"
+
+  def notNamed(x: String): Boolean = x.startsWith(PREFIX + NAME)
+  def isNamed(x: String): Boolean = !notNamed(x)
 
   def apply(seed: String, t: CypherType): Var = Var(s"$PREFIX$seed")(t)
 
-  def apply(id: Int, t: CypherType): Var = apply(s"FRESH_VAR$id", t)
+  def apply(id: Int, t: CypherType): Var = apply(s"$NAME$id", t)
 }

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/IRBuilderContext.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/IRBuilderContext.scala
@@ -83,6 +83,10 @@ final case class IRBuilderContext(
     copy(knownPatterns = Seq.empty)
   }
 
+  def resetKnownTypes: IRBuilderContext = {
+    copy(knownTypes = Map.empty)
+  }
+
   def registerGraph(qgn: QualifiedGraphName, graph: PropertyGraph): IRBuilderContext =
     copy(queryLocalCatalog = queryLocalCatalog.withGraph(qgn, graph))
 

--- a/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/IRBuilderContext.scala
+++ b/okapi-ir/src/main/scala/org/opencypher/okapi/ir/impl/IRBuilderContext.scala
@@ -51,7 +51,8 @@ final case class IRBuilderContext(
   queryLocalCatalog: QueryLocalCatalog, // copy of Session catalog plus constructed graph schemas
   // TODO: Unify instantiateView and queryCatalog into one abstraction that resolves graphs/views
   instantiateView: ViewInvocation => PropertyGraph,
-  knownTypes: Map[ast.Expression, CypherType] = Map.empty) {
+  knownTypes: Map[ast.Expression, CypherType] = Map.empty,
+  knownPatterns: Seq[Pattern] = Seq.empty) {
   self =>
 
   private lazy val exprConverter = new ExpressionConverter(self)
@@ -78,6 +79,10 @@ final case class IRBuilderContext(
   def withWorkingGraph(graph: IRGraph): IRBuilderContext =
     copy(workingGraph = graph)
 
+  def resetKnownPatterns: IRBuilderContext = {
+    copy(knownPatterns = Seq.empty)
+  }
+
   def registerGraph(qgn: QualifiedGraphName, graph: PropertyGraph): IRBuilderContext =
     copy(queryLocalCatalog = queryLocalCatalog.withGraph(qgn, graph))
 
@@ -87,6 +92,10 @@ final case class IRBuilderContext(
   def resetRegistry: IRBuilderContext = {
     val sourceBlock = SourceBlock(workingGraph)
     copy(blockRegistry = BlockRegistry.empty.register(sourceBlock))
+  }
+
+  def registerPattern(pattern: Pattern): IRBuilderContext = {
+    copy(knownPatterns = knownPatterns :+ pattern)
   }
 }
 

--- a/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
+++ b/okapi-ir/src/test/scala/org/opencypher/okapi/ir/impl/IrBuilderTest.scala
@@ -30,7 +30,7 @@ import org.opencypher.okapi.api.graph.{GraphName, Namespace, QualifiedGraphName}
 import org.opencypher.okapi.api.schema.{PropertyGraphSchema, PropertyKeys}
 import org.opencypher.okapi.api.types._
 import org.opencypher.okapi.api.value.CypherValue._
-import org.opencypher.okapi.impl.exception.UnsupportedOperationException
+import org.opencypher.okapi.impl.exception.{UnsupportedOperationException, IllegalArgumentException}
 import org.opencypher.okapi.ir.api._
 import org.opencypher.okapi.ir.api.block._
 import org.opencypher.okapi.ir.api.expr._
@@ -782,7 +782,30 @@ class IrBuilderTest extends IrTestSuite {
            |  CREATE (a)-[e]->(b)
            |RETURN GRAPH""".stripMargin
 
-      an[UnsupportedOperationException] shouldBe thrownBy(query.asCypherQuery().model.result)
+      an[IllegalArgumentException] shouldBe thrownBy(query.asCypherQuery().model.result)
+    }
+
+    it("WITH using all pattern-elements") {
+      val query =
+        """|MATCH (a)-[e]->(b)
+           |WITH b, a, e
+           |CONSTRUCT
+           |  CREATE (a)-[e]->(b)
+           |RETURN GRAPH""".stripMargin
+
+      query.asCypherQuery().model.result
+    }
+
+    it("WITH using all pattern-elements and alias") {
+      val query =
+        """|MATCH (a)-[e]->(b)
+           |WITH b as x, a as y, e as r
+           |CONSTRUCT
+           |  CREATE (y)-[r]->(x)
+           |RETURN GRAPH""".stripMargin
+
+      query.asCypherQuery().model.result
+
     }
 
     it("CONSTRUCT clears scope for following CONSTRUCT") {
@@ -831,7 +854,7 @@ class IrBuilderTest extends IrTestSuite {
            |  CREATE (a)-[e]->(x)
            |RETURN GRAPH""".stripMargin
 
-      an[UnsupportedOperationException] shouldBe thrownBy(query.asCypherQuery(graphNameA -> inputSchemaA, graphNameB -> inputSchemaB).model.result)
+      an[IllegalArgumentException] shouldBe thrownBy(query.asCypherQuery(graphNameA -> inputSchemaA, graphNameB -> inputSchemaB).model.result)
     }
   }
 


### PR DESCRIPTION
cloned relationships should not be allowed in the patterns, with the matched source and target node.

The solution checks the relationship patterns in the CONSTRUCT-clauses by matching against propagated MATCH-patterns.