### PR TITLE
Fix PGDS id generation

### DIFF
--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/api/io/FullPGDSAcceptanceTest.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/api/io/FullPGDSAcceptanceTest.scala
@@ -212,7 +212,13 @@ class FullPGDSAcceptanceTest extends MorpheusTestSuite
         .withRelationshipType(Set("A", "B"), Set("S"), Set("A", "B"))
         .withRelationshipType(Set("A", "C"), Set("T"), Set("A", "B")),
       g3 -> GraphType.empty.withElementType("A").withNodeType("A"),
-      g4 -> GraphType.empty.withElementType("A").withNodeType("A")
+      g4 -> GraphType.empty.withElementType("A").withNodeType("A"),
+      g5 -> GraphType.empty.withElementType("USER", "name" -> CTString)
+        .withElementType("BUSINESS")
+        .withElementType("REVIEWS", "rating" -> CTFloat)
+        .withNodeType("USER")
+        .withNodeType("BUSINESS")
+        .withRelationshipType(Set("USER"), Set("REVIEWS"), Set("BUSINESS"))
     )
 
     def writeTable(df: DataFrame, tableName: String): Unit

--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/api/io/FullPGDSAcceptanceTest.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/api/io/FullPGDSAcceptanceTest.scala
@@ -215,7 +215,7 @@ class FullPGDSAcceptanceTest extends MorpheusTestSuite
       g4 -> GraphType.empty.withElementType("A").withNodeType("A"),
       g5 -> GraphType.empty.withElementType("USER", "name" -> CTString)
         .withElementType("BUSINESS")
-        .withElementType("REVIEWS", "rating" -> CTFloat)
+        .withElementType("REVIEWS", "rating" -> CTFloat.nullable)
         .withNodeType("USER")
         .withNodeType("BUSINESS")
         .withRelationshipType(Set("USER"), Set("REVIEWS"), Set("BUSINESS"))

--- a/morpheus-testing/src/test/scala/org/opencypher/morpheus/api/io/sql/SqlPropertyGraphDataSourceTest.scala
+++ b/morpheus-testing/src/test/scala/org/opencypher/morpheus/api/io/sql/SqlPropertyGraphDataSourceTest.scala
@@ -421,7 +421,7 @@ class SqlPropertyGraphDataSourceTest extends MorpheusTestSuite with HiveFixture 
       .toDF("book_id", "book_title")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$bookView")
     sparkSession
-      .createDataFrame(Seq((0L, 1L, 42.23)))
+      .createDataFrame(Seq((0L, 1L, 13.37)))
       .toDF("person", "book", "rating")
       .write.mode(SaveMode.Overwrite).saveAsTable(s"$databaseName.$readsView1")
     sparkSession
@@ -444,8 +444,15 @@ class SqlPropertyGraphDataSourceTest extends MorpheusTestSuite with HiveFixture 
       .cypher("MATCH ()-[r]->() RETURN type(r) AS type, r.rating as rating")
       .records.toMaps should equal(
       Bag(
-        CypherMap("type" -> "READS", "rating" -> 42.23),
+        CypherMap("type" -> "READS", "rating" -> 13.37),
         CypherMap("type" -> "READS", "rating" -> 13.37)
+      ))
+
+    ds.graph(fooGraphName)
+      .cypher("MATCH ()-[r]->() WITH type(r) AS type, id(r) AS id RETURN count(distinct id) AS distinct_ids")
+      .records.toMaps should equal(
+      Bag(
+        CypherMap("distinct_ids" -> 2)
       ))
   }
 

--- a/okapi-testing/src/main/scala/org/opencypher/okapi/testing/PGDSAcceptanceTest.scala
+++ b/okapi-testing/src/main/scala/org/opencypher/okapi/testing/PGDSAcceptanceTest.scala
@@ -135,7 +135,9 @@ trait PGDSAcceptanceTest[Session <: CypherSession, Graph <: PropertyGraph] {
       """
         |CREATE (a:USER {name: "Bob"})-[:REVIEWS{rating: 0.0}]->(b:BUSINESS),
         |       (a)-[:REVIEWS{rating: 3.0}]->(b),
-        |       (a)-[:REVIEWS{rating: 5.0}]->(b)
+        |       (a)-[:REVIEWS{rating: 5.0}]->(b),
+        |       (a)-[:REVIEWS]->(b),
+        |       (a)-[:REVIEWS]->(b)
       """.stripMargin
   )
 
@@ -262,7 +264,7 @@ trait PGDSAcceptanceTest[Session <: CypherSession, Graph <: PropertyGraph] {
       Scenario("API: PropertyGraphDataSource: unique IDs for graph #4", g5) { implicit ctx: TestContext =>
         registerPgds(ns)
         val result = session.catalog.graph(QualifiedGraphName(ns, g5)).cypher("MATCH (a)-[r]->(b) RETURN DISTINCT id(r)").records
-        result.size should equal(3)
+        result.size should equal(5)
       },
 
       Scenario("API: Cypher query directly on graph #1", g1) { implicit ctx: TestContext =>

--- a/okapi-testing/src/main/scala/org/opencypher/okapi/testing/PGDSAcceptanceTest.scala
+++ b/okapi-testing/src/main/scala/org/opencypher/okapi/testing/PGDSAcceptanceTest.scala
@@ -261,7 +261,7 @@ trait PGDSAcceptanceTest[Session <: CypherSession, Graph <: PropertyGraph] {
         session.catalog.source(ns).graph(g3).relationships("r").size shouldBe 0
       },
 
-      Scenario("API: PropertyGraphDataSource: unique IDs for graph #4", g5) { implicit ctx: TestContext =>
+      Scenario("API: PropertyGraphDataSource: unique IDs for graph #5", g5) { implicit ctx: TestContext =>
         registerPgds(ns)
         val result = session.catalog.graph(QualifiedGraphName(ns, g5)).cypher("MATCH (a)-[r]->(b) RETURN DISTINCT id(r)").records
         result.size should equal(5)


### PR DESCRIPTION
serialized relationship ids are not based on property columns anymore, as this lead to errors with unsupported types for serialization.
Instead a monotonically_increasing_id() is used for unique ids between multiple relationships.